### PR TITLE
Add Shutdown to startTTLEvictionDaemon

### DIFF
--- a/tlru.go
+++ b/tlru.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"context"
 )
 
 // TLRU cache public interface

--- a/tlru.go
+++ b/tlru.go
@@ -498,9 +498,7 @@ func (c *tlru) evictExpiredEntries() {
 	}
 }
 
-func (c *tlru) startTTLEvictionDaemon() {
-	defer close(*c.config.EvictionChannel)
-
+func (c *tlru) startTTLEvictionDaemon() { 
 	for {
 		timer := time.NewTimer(c.garbageCollectionInterval)
 		select {
@@ -508,6 +506,7 @@ func (c *tlru) startTTLEvictionDaemon() {
 			if !timer.Stop() {
 				<-timer.C
 			}
+			close(*c.config.EvictionChannel)
 			return
 		case <-timer.C:
 			c.Lock()

--- a/tlru.go
+++ b/tlru.go
@@ -186,7 +186,7 @@ type tlru struct {
 	tailNode                  *doublyLinkedNode
 	garbageCollectionInterval time.Duration
 	ctx                       context.Context
-	Shutdown                  context.CancelFunc
+	cancelFunc                context.CancelFunc
 }
 
 // New returns a new instance of TLRU cache
@@ -208,7 +208,7 @@ func New(config Config) TLRU {
 	}
 
 	cache.initializeDoublyLinkedList()
-	cache.ctx, cache.Shutdown = context.WithCancel(context.Background())
+	cache.ctx, cache.cancelFunc = context.WithCancel(context.Background())
 	go cache.startTTLEvictionDaemon()
 
 	return cache
@@ -515,4 +515,8 @@ func (c *tlru) startTTLEvictionDaemon() {
 			c.Unlock()
 		}
 	}
+}
+
+func (c *tlru) Shutdown() {
+	c.cancelFunc()
 }

--- a/tlru.go
+++ b/tlru.go
@@ -76,6 +76,9 @@ type TLRU interface {
 
 	// Has returns true if the provided keys exists in cache otherwise it returns false
 	Has(key string) bool
+
+	// Shutdown stops the garabage collection daemon
+	Shutdown()
 }
 
 // Config of tlru cache

--- a/tlru.go
+++ b/tlru.go
@@ -77,6 +77,9 @@ type TLRU interface {
 	// Has returns true if the provided keys exists in cache otherwise it returns false
 	Has(key string) bool
 
+	// Run starts the garabage collection daemon
+	Run(context.Context)
+
 	// Shutdown stops the garabage collection daemon
 	Shutdown()
 }

--- a/tlru.go
+++ b/tlru.go
@@ -77,8 +77,8 @@ type TLRU interface {
 	// Has returns true if the provided keys exists in cache otherwise it returns false
 	Has(key string) bool
 
-	// Run starts the garabage collection daemon
-	Run(context.Context)
+	// Start starts the garabage collection daemon
+	Start(context.Context)
 
 	// Shutdown stops the garabage collection daemon
 	Shutdown()

--- a/tlru.go
+++ b/tlru.go
@@ -205,7 +205,7 @@ func New(config Config) TLRU {
 	}
 
 	cache.initializeDoublyLinkedList()
-	cache.ctx, cache.cancel = context.WithCancel(context.Background())
+	cache.ctx, cache.Shutdown = context.WithCancel(context.Background())
 	go cache.startTTLEvictionDaemon()
 
 	return cache


### PR DESCRIPTION
Add the ability to shutdown startTTLEvictionDaemon.

This prevents go routine leaks when the cache is no longer in use.